### PR TITLE
 Removed static references to SPI instances (backport from jsr354-api)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <basedir>.</basedir>
         <!-- Dependency versions -->
         <testng.version>6.8.5</testng.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
 
     <organization>
@@ -369,6 +370,12 @@
                 <version>${testng.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-all</artifactId>
+              <version>${mockito.version}</version>
+              <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -376,6 +383,11 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -447,7 +459,7 @@
                     <configuration>
                         <skipTests>false</skipTests>
                         <trimStackTrace>false</trimStackTrace>
-                        <forkMode>once</forkMode>
+                        <forkMode>never</forkMode>
                         <useSystemClassLoader>true</useSystemClassLoader>
                         <includes>
                             <include>**/*Test.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
                     <configuration>
                         <skipTests>false</skipTests>
                         <trimStackTrace>false</trimStackTrace>
-                        <forkMode>never</forkMode>
+                        <forkMode>once</forkMode>
                         <useSystemClassLoader>true</useSystemClassLoader>
                         <includes>
                             <include>**/*Test.java</include>

--- a/src/main/java/javax/money/Monetary.java
+++ b/src/main/java/javax/money/Monetary.java
@@ -35,37 +35,7 @@ public final class Monetary {
     /**
      * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
      */
-    private static final MonetaryCurrenciesSingletonSpi monetaryCurrenciesSpi = loadMonetaryCurrenciesSingletonSpi();
-
-    /**
-     * The used {@link javax.money.spi.MonetaryAmountsSingletonSpi} instance.
-     */
-    private static final MonetaryAmountsSingletonSpi monetaryAmountsSingletonSpi = loadMonetaryAmountsSingletonSpi();
-
-    /**
-     * The used {@link javax.money.spi.MonetaryAmountsSingletonSpi} instance.
-     */
-    private static final MonetaryAmountsSingletonQuerySpi monetaryAmountsSingletonQuerySpi =
-            loadMonetaryAmountsSingletonQuerySpi();
-
-    /**
-     * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
-     */
-    private static final MonetaryRoundingsSingletonSpi monetaryRoundingsSpi = loadMonetaryRoundingsSingletonSpi();
-
-
-    /**
-     * Required for deserialization only.
-     */
-    private Monetary() {
-    }
-
-    /**
-     * Loads the SPI backing bean.
-     *
-     * @return the {@link MonetaryCurrenciesSingletonSpi} backing bean to be used.
-     */
-    private static MonetaryCurrenciesSingletonSpi loadMonetaryCurrenciesSingletonSpi() {
+    private static final MonetaryCurrenciesSingletonSpi monetaryCurrenciesSpi() {
         try {
             MonetaryCurrenciesSingletonSpi spi = Bootstrap
                     .getService(MonetaryCurrenciesSingletonSpi.class);
@@ -81,11 +51,9 @@ public final class Monetary {
     }
 
     /**
-     * Loads the SPI backing bean.
-     *
-     * @return the MonetaryAmountsSingletonSpi bean from the bootstrapping logic.
+     * The used {@link javax.money.spi.MonetaryAmountsSingletonSpi} instance.
      */
-    private static MonetaryAmountsSingletonSpi loadMonetaryAmountsSingletonSpi() {
+    private static final MonetaryAmountsSingletonSpi monetaryAmountsSingletonSpi() {
         try {
             return Bootstrap.getService(MonetaryAmountsSingletonSpi.class);
         } catch (Exception e) {
@@ -96,11 +64,9 @@ public final class Monetary {
     }
 
     /**
-     * Loads the SPI backing bean.
-     *
-     * @return the MonetaryAmountsSingletonQuerySpi bean from the bootstrapping logic.
+     * The used {@link javax.money.spi.MonetaryAmountsSingletonSpi} instance.
      */
-    private static MonetaryAmountsSingletonQuerySpi loadMonetaryAmountsSingletonQuerySpi() {
+    private static final MonetaryAmountsSingletonQuerySpi monetaryAmountsSingletonQuerySpi() { 
         try {
             return Bootstrap.getService(MonetaryAmountsSingletonQuerySpi.class);
         } catch (Exception e) {
@@ -113,11 +79,9 @@ public final class Monetary {
     }
 
     /**
-     * Loads the SPI backing bean.
-     *
-     * @return an instance of MonetaryRoundingsSingletonSpi.
+     * The used {@link javax.money.spi.MonetaryCurrenciesSingletonSpi} instance.
      */
-    private static MonetaryRoundingsSingletonSpi loadMonetaryRoundingsSingletonSpi() {
+    private static final MonetaryRoundingsSingletonSpi monetaryRoundingsSpi() {
         try {
             MonetaryRoundingsSingletonSpi spi = Bootstrap
                     .getService(MonetaryRoundingsSingletonSpi.class);
@@ -134,6 +98,12 @@ public final class Monetary {
 
 
     /**
+     * Required for deserialization only.
+     */
+    private Monetary() {
+    }
+
+    /**
      * Access a new instance based on the currency code. Currencies are
      * available as provided by {@link CurrencyProviderSpi} instances registered
      * with the {@link javax.money.spi.Bootstrap}.
@@ -144,10 +114,10 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static CurrencyUnit getCurrency(String currencyCode, String... providers) {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getCurrency(currencyCode, providers);
+        return monetaryCurrenciesSpi().getCurrency(currencyCode, providers);
     }
 
     /**
@@ -162,10 +132,10 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static CurrencyUnit getCurrency(Locale locale, String... providers) {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getCurrency(locale, providers);
+        return monetaryCurrenciesSpi().getCurrency(locale, providers);
     }
 
     /**
@@ -180,10 +150,10 @@ public final class Monetary {
      * @throws UnknownCurrencyException if no such currency exists.
      */
     public static Set<CurrencyUnit> getCurrencies(Locale locale, String... providers) {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getCurrencies(locale, providers);
+        return monetaryCurrenciesSpi().getCurrencies(locale, providers);
     }
 
     /**
@@ -196,10 +166,10 @@ public final class Monetary {
      * would return a result for the given code.
      */
     public static boolean isCurrencyAvailable(String code, String... providers) {
-        if(monetaryCurrenciesSpi==null){
+        if(monetaryCurrenciesSpi()==null){
             throw new IllegalStateException("No Monetary Spi loaded.");
         }
-        return monetaryCurrenciesSpi.isCurrencyAvailable(code, providers);
+        return monetaryCurrenciesSpi().isCurrencyAvailable(code, providers);
     }
 
     /**
@@ -212,10 +182,10 @@ public final class Monetary {
      * result containing a currency with the given code.
      */
     public static boolean isCurrencyAvailable(Locale locale, String... providers) {
-        if(monetaryCurrenciesSpi==null){
+        if(monetaryCurrenciesSpi()==null){
             throw new IllegalStateException("No Monetary Spi loaded.");
         }
-        return monetaryCurrenciesSpi.isCurrencyAvailable(locale, providers);
+        return monetaryCurrenciesSpi().isCurrencyAvailable(locale, providers);
     }
 
     /**
@@ -225,10 +195,10 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Collection<CurrencyUnit> getCurrencies(String... providers) {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getCurrencies(providers);
+        return monetaryCurrenciesSpi().getCurrencies(providers);
     }
 
     /**
@@ -238,10 +208,10 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static CurrencyUnit getCurrency(CurrencyQuery query) {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getCurrency(query);
+        return monetaryCurrenciesSpi().getCurrency(query);
     }
 
 
@@ -252,10 +222,10 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Collection<CurrencyUnit> getCurrencies(CurrencyQuery query) {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getCurrencies(query);
+        return monetaryCurrenciesSpi().getCurrencies(query);
     }
 
     /**
@@ -264,10 +234,10 @@ public final class Monetary {
      * @return the list of known currencies, never null.
      */
     public static Set<String> getCurrencyProviderNames() {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getProviderNames();
+        return monetaryCurrenciesSpi().getProviderNames();
     }
 
     /**
@@ -277,10 +247,10 @@ public final class Monetary {
      * @return the orderend list provider names, modelling the default provider chain used, never null.
      */
     public static List<String> getDefaultCurrencyProviderChain() {
-        if(monetaryCurrenciesSpi==null) {
+        if(monetaryCurrenciesSpi()==null) {
             throw new MonetaryException("No MonetaryCurrenciesSingletonSpi loaded, check your system setup.");
         }
-        return monetaryCurrenciesSpi.getDefaultProviderChain();
+        return monetaryCurrenciesSpi().getDefaultProviderChain();
     }
 
     /**
@@ -293,11 +263,11 @@ public final class Monetary {
      *                           implementation class is registered.
      */
     public static <T extends MonetaryAmount> MonetaryAmountFactory<T> getAmountFactory(Class<T> amountType) {
-        if(monetaryAmountsSingletonQuerySpi==null){
+        if(monetaryAmountsSingletonSpi()==null){
             throw new MonetaryException(
-                    "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available.");
+                    "No MonetaryAmountsSingletonSpi loaded, query functionality is not available.");
         }
-        MonetaryAmountFactory<T> factory = monetaryAmountsSingletonSpi.getAmountFactory(amountType);
+        MonetaryAmountFactory<T> factory = monetaryAmountsSingletonSpi().getAmountFactory(amountType);
         if(factory==null){
             throw new MonetaryException("No AmountFactory available for type: " + amountType.getName());
         }
@@ -314,11 +284,11 @@ public final class Monetary {
      *                           implementation class is registered.
      */
     public static MonetaryAmountFactory<?> getDefaultAmountFactory() {
-        if(monetaryAmountsSingletonSpi==null){
+        if(monetaryAmountsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonSpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonSpi.getDefaultAmountFactory();
+        return monetaryAmountsSingletonSpi().getDefaultAmountFactory();
     }
 
     /**
@@ -329,11 +299,11 @@ public final class Monetary {
      * corresponding {@link MonetaryAmountFactory} instances provided, never {@code null}
      */
     public static Collection<MonetaryAmountFactory<?>> getAmountFactories() {
-        if(monetaryAmountsSingletonSpi==null){
+        if(monetaryAmountsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonSpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonSpi.getAmountFactories();
+        return monetaryAmountsSingletonSpi().getAmountFactories();
     }
 
     /**
@@ -344,11 +314,11 @@ public final class Monetary {
      * corresponding {@link MonetaryAmountFactory} instances provided, never {@code null}
      */
     public static Collection<Class<? extends MonetaryAmount>> getAmountTypes() {
-        if(monetaryAmountsSingletonSpi==null){
+        if(monetaryAmountsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonSpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonSpi.getAmountTypes();
+        return monetaryAmountsSingletonSpi().getAmountTypes();
     }
 
     /**
@@ -358,11 +328,11 @@ public final class Monetary {
      * @return all current default {@link MonetaryAmount} implementation class, never {@code null}
      */
     public static Class<? extends MonetaryAmount> getDefaultAmountType() {
-        if(monetaryAmountsSingletonSpi==null){
+        if(monetaryAmountsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonSpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonSpi.getDefaultAmountType();
+        return monetaryAmountsSingletonSpi().getDefaultAmountType();
     }
 
     /**
@@ -373,11 +343,11 @@ public final class Monetary {
      * @return the factory found, or null.
      */
     public static MonetaryAmountFactory getAmountFactory(MonetaryAmountFactoryQuery query) {
-        if(monetaryAmountsSingletonQuerySpi==null){
+        if(monetaryAmountsSingletonQuerySpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonQuerySpi.getAmountFactory(query);
+        return monetaryAmountsSingletonQuerySpi().getAmountFactory(query);
     }
 
     /**
@@ -387,11 +357,11 @@ public final class Monetary {
      * @return the instances found, never null.
      */
     public static Collection<MonetaryAmountFactory<?>> getAmountFactories(MonetaryAmountFactoryQuery query) {
-        if(monetaryAmountsSingletonQuerySpi==null){
+        if(monetaryAmountsSingletonQuerySpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonQuerySpi.getAmountFactories(query);
+        return monetaryAmountsSingletonQuerySpi().getAmountFactories(query);
     }
 
     /**
@@ -401,11 +371,11 @@ public final class Monetary {
      * @return true, if at least one {@link MonetaryAmountFactory} matches the query.
      */
     public static boolean isAvailable(MonetaryAmountFactoryQuery query) {
-        if(monetaryAmountsSingletonQuerySpi==null){
+        if(monetaryAmountsSingletonQuerySpi()==null){
             throw new MonetaryException(
                     "No MonetaryAmountsSingletonQuerySpi loaded, query functionality is not available.");
         }
-        return monetaryAmountsSingletonQuerySpi.isAvailable(query);
+        return monetaryAmountsSingletonQuerySpi().isAvailable(query);
     }
 
     /**
@@ -417,10 +387,10 @@ public final class Monetary {
      * @return the (shared) default rounding instance.
      */
     public static MonetaryRounding getDefaultRounding() {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getDefaultRounding();
+        return monetaryRoundingsSpi().getDefaultRounding();
     }
 
 
@@ -437,10 +407,10 @@ public final class Monetary {
      * rounding, never {@code null}.
      */
     public static MonetaryRounding getRounding(CurrencyUnit currencyUnit, String... providers) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getRounding(currencyUnit, providers);
+        return monetaryRoundingsSpi().getRounding(currencyUnit, providers);
     }
 
     /**
@@ -456,10 +426,10 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static MonetaryRounding getRounding(String roundingName, String... providers) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getRounding(roundingName, providers);
+        return monetaryRoundingsSpi().getRounding(roundingName, providers);
     }
 
     /**
@@ -472,10 +442,10 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static MonetaryRounding getRounding(RoundingQuery roundingQuery) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getRounding(roundingQuery);
+        return monetaryRoundingsSpi().getRounding(roundingQuery);
     }
 
     /**
@@ -489,10 +459,10 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(String roundingName, String... providers) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.isRoundingAvailable(roundingName, providers);
+        return monetaryRoundingsSpi().isRoundingAvailable(roundingName, providers);
     }
 
     /**
@@ -507,10 +477,10 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(CurrencyUnit currencyUnit, String... providers) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.isRoundingAvailable(currencyUnit, providers);
+        return monetaryRoundingsSpi().isRoundingAvailable(currencyUnit, providers);
     }
 
     /**
@@ -523,10 +493,10 @@ public final class Monetary {
      *                                  {@link javax.money.spi.RoundingProviderSpi} instance.
      */
     public static boolean isRoundingAvailable(RoundingQuery roundingQuery) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.isRoundingAvailable(roundingQuery);
+        return monetaryRoundingsSpi().isRoundingAvailable(roundingQuery);
     }
 
 
@@ -538,10 +508,10 @@ public final class Monetary {
      * @return all {@link MonetaryRounding} instances macthing the query, never {@code null}.
      */
     public static Collection<MonetaryRounding> getRoundings(RoundingQuery roundingQuery) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getRoundings(roundingQuery);
+        return monetaryRoundingsSpi().getRoundings(roundingQuery);
     }
 
 
@@ -553,10 +523,10 @@ public final class Monetary {
      * @return the set of custom rounding ids, never {@code null}.
      */
     public static Set<String> getRoundingNames(String... providers) {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getRoundingNames(providers);
+        return monetaryRoundingsSpi().getRoundingNames(providers);
     }
 
     /**
@@ -565,10 +535,10 @@ public final class Monetary {
      * @return the set of provider names, never {@code null}.
      */
     public static Set<String> getRoundingProviderNames() {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getProviderNames();
+        return monetaryRoundingsSpi().getProviderNames();
     }
 
 
@@ -578,10 +548,10 @@ public final class Monetary {
      * @return the chained list of provider names, never {@code null}.
      */
     public static List<String> getDefaultRoundingProviderChain() {
-        if(monetaryRoundingsSpi==null){
+        if(monetaryRoundingsSpi()==null){
             throw new MonetaryException("No MonetaryRoundingsSpi loaded, query functionality is not available.");
         }
-        return monetaryRoundingsSpi.getDefaultProviderChain();
+        return monetaryRoundingsSpi().getDefaultProviderChain();
     }
 
 

--- a/src/main/java/javax/money/convert/MonetaryConversions.java
+++ b/src/main/java/javax/money/convert/MonetaryConversions.java
@@ -52,9 +52,7 @@ public final class MonetaryConversions{
      * The SPI currently active, use {@link java.util.ServiceLoader} to register an
      * alternate implementation.
      */
-    private static final MonetaryConversionsSingletonSpi MONETARY_CONVERSION_SPI = loadSpi();
-
-    private static MonetaryConversionsSingletonSpi loadSpi() {
+    private static final MonetaryConversionsSingletonSpi getMonetaryConversionsSpi() {
         MonetaryConversionsSingletonSpi spi = Bootstrap.getService(MonetaryConversionsSingletonSpi.class);
         if(spi==null){
             throw new MonetaryException("MonetaryConversionsSingletonSpi no available: no conversion will be possible.");
@@ -81,11 +79,11 @@ public final class MonetaryConversions{
         Objects.requireNonNull(providers);
         Objects.requireNonNull(termCurrency);
         if(providers.length == 0){
-            return MONETARY_CONVERSION_SPI.getConversion(
+            return getMonetaryConversionsSpi().getConversion(
                     ConversionQueryBuilder.of().setTermCurrency(termCurrency).setProviderNames(getDefaultConversionProviderChain())
                             .build());
         }
-        return MONETARY_CONVERSION_SPI.getConversion(
+        return getMonetaryConversionsSpi().getConversion(
                 ConversionQueryBuilder.of().setTermCurrency(termCurrency).setProviderNames(providers).build());
     }
 
@@ -113,11 +111,11 @@ public final class MonetaryConversions{
      * @throws IllegalArgumentException if the query defines {@link ExchangeRateProvider}s that are not available.
      */
     public static CurrencyConversion getConversion(ConversionQuery conversionQuery){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.getConversion(conversionQuery);
+        return getMonetaryConversionsSpi().getConversion(conversionQuery);
     }
 
     /**
@@ -127,11 +125,11 @@ public final class MonetaryConversions{
      * @return true, if a conversion is accessible from {@link #getConversion(ConversionQuery)}.
      */
     public static boolean isConversionAvailable(ConversionQuery conversionQuery){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.isConversionAvailable(conversionQuery);
+        return getMonetaryConversionsSpi().isConversionAvailable(conversionQuery);
     }
 
     /**
@@ -143,11 +141,11 @@ public final class MonetaryConversions{
      * @return true, if a conversion is accessible from {@link #getConversion(String, String...)}.
      */
     public static boolean isConversionAvailable(String currencyCode, String... providers){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.isConversionAvailable(Monetary.getCurrency(currencyCode), providers);
+        return getMonetaryConversionsSpi().isConversionAvailable(Monetary.getCurrency(currencyCode), providers);
     }
 
     /**
@@ -158,11 +156,11 @@ public final class MonetaryConversions{
      * @return true, if a conversion is accessible from {@link #getConversion(String, String...)}.
      */
     public static boolean isConversionAvailable(CurrencyUnit termCurrency, String... providers){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.isConversionAvailable(termCurrency, providers);
+        return getMonetaryConversionsSpi().isConversionAvailable(termCurrency, providers);
     }
 
     /**
@@ -176,10 +174,10 @@ public final class MonetaryConversions{
     public static ExchangeRateProvider getExchangeRateProvider(String... providers){
         if(providers.length == 0){
             List<String> defaultProviderChain = getDefaultConversionProviderChain();
-            return MONETARY_CONVERSION_SPI.getExchangeRateProvider(ConversionQueryBuilder.of().setProviderNames(
+            return getMonetaryConversionsSpi().getExchangeRateProvider(ConversionQueryBuilder.of().setProviderNames(
                     defaultProviderChain.toArray(new String[defaultProviderChain.size()])).build());
         }
-        ExchangeRateProvider provider = MONETARY_CONVERSION_SPI
+        ExchangeRateProvider provider = getMonetaryConversionsSpi()
                 .getExchangeRateProvider(ConversionQueryBuilder.of().setProviderNames(providers).build());
         if(provider==null){
             throw new MonetaryException("No such rate provider: " + Arrays.toString(providers));
@@ -223,11 +221,11 @@ public final class MonetaryConversions{
      * @throws IllegalArgumentException if no such {@link ExchangeRateProvider} is available.
      */
     public static ExchangeRateProvider getExchangeRateProvider(ConversionQuery conversionQuery){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.getExchangeRateProvider(conversionQuery);
+        return getMonetaryConversionsSpi().getExchangeRateProvider(conversionQuery);
     }
 
     /**
@@ -237,11 +235,11 @@ public final class MonetaryConversions{
      * @return true, if a rate provider is accessible from {@link #getExchangeRateProvider(ConversionQuery)}}.
      */
     public static boolean isExchangeRateProviderAvailable(ConversionQuery conversionQuery){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.isExchangeRateProviderAvailable(conversionQuery);
+        return getMonetaryConversionsSpi().isExchangeRateProviderAvailable(conversionQuery);
     }
 
 
@@ -253,11 +251,11 @@ public final class MonetaryConversions{
      * @return all supported provider ids, never {@code null}.
      */
     public static Collection<String> getConversionProviderNames(){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return MONETARY_CONVERSION_SPI.getProviderNames();
+        return getMonetaryConversionsSpi().getProviderNames();
     }
 
     /**
@@ -266,13 +264,13 @@ public final class MonetaryConversions{
      * @return the default provider, never {@code null}.
      */
     public static List<String> getDefaultConversionProviderChain(){
-        if(MONETARY_CONVERSION_SPI==null){
+        if(getMonetaryConversionsSpi()==null){
             throw new MonetaryException(
                     "No MonetaryConveresionsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        List<String> defaultChain = MONETARY_CONVERSION_SPI.getDefaultProviderChain();
+        List<String> defaultChain = getMonetaryConversionsSpi().getDefaultProviderChain();
         Objects.requireNonNull(defaultChain, "No default provider chain provided by SPI: " +
-                MONETARY_CONVERSION_SPI.getClass().getName());
+                getMonetaryConversionsSpi().getClass().getName());
         return defaultChain;
     }
 

--- a/src/main/java/javax/money/format/MonetaryFormats.java
+++ b/src/main/java/javax/money/format/MonetaryFormats.java
@@ -8,14 +8,22 @@
  */
 package javax.money.format;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.money.MonetaryException;
 import javax.money.spi.Bootstrap;
 import javax.money.spi.MonetaryAmountFormatProviderSpi;
 import javax.money.spi.MonetaryFormatsSingletonSpi;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This class models the singleton accessor for {@link MonetaryAmountFormat} instances.
@@ -27,21 +35,7 @@ import java.util.logging.Logger;
  */
 public final class MonetaryFormats {
 
-    private static final MonetaryFormatsSingletonSpi monetaryFormatsSingletonSpi = loadMonetaryFormatsSingletonSpi();
-
-    /**
-     * Private singleton constructor.
-     */
-    private MonetaryFormats() {
-        // Singleton
-    }
-
-    /**
-     * Loads the SPI backing bean.
-     *
-     * @return the instance of MonetaryFormatsSingletonSpi to be used by this singleton.
-     */
-    private static MonetaryFormatsSingletonSpi loadMonetaryFormatsSingletonSpi() {
+    private static final MonetaryFormatsSingletonSpi monetaryFormatsSingletonSpi() {
         try {
             MonetaryFormatsSingletonSpi spi = Bootstrap.getService(MonetaryFormatsSingletonSpi.class);
             if(spi==null){
@@ -56,6 +50,13 @@ public final class MonetaryFormats {
     }
 
     /**
+     * Private singleton constructor.
+     */
+    private MonetaryFormats() {
+        // Singleton
+    }
+
+    /**
      * Checks if a {@link MonetaryAmountFormat} is available for the given {@link java.util.Locale} and providers.
      *
      * @param locale    the target {@link java.util.Locale}, not {@code null}.
@@ -64,11 +65,11 @@ public final class MonetaryFormats {
      * @return true, if a corresponding {@link MonetaryAmountFormat} is accessible.
      */
     public static boolean isAvailable(Locale locale, String... providers) {
-        if(monetaryFormatsSingletonSpi==null){
+        if(monetaryFormatsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return monetaryFormatsSingletonSpi.isAvailable(locale, providers);
+        return monetaryFormatsSingletonSpi().isAvailable(locale, providers);
     }
 
     /**
@@ -94,11 +95,11 @@ public final class MonetaryFormats {
      * @return true, if a corresponding {@link MonetaryAmountFormat} is accessible.
      */
     public static boolean isAvailable(AmountFormatQuery formatQuery) {
-        if(monetaryFormatsSingletonSpi==null){
+        if(monetaryFormatsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return monetaryFormatsSingletonSpi.isAvailable(formatQuery);
+        return monetaryFormatsSingletonSpi().isAvailable(formatQuery);
     }
 
     /**
@@ -112,11 +113,11 @@ public final class MonetaryFormats {
      *                           corresponding {@link MonetaryAmountFormat} instance.
      */
     public static MonetaryAmountFormat getAmountFormat(AmountFormatQuery formatQuery) {
-        if(monetaryFormatsSingletonSpi==null){
+        if(monetaryFormatsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return monetaryFormatsSingletonSpi.getAmountFormat(formatQuery);
+        return monetaryFormatsSingletonSpi().getAmountFormat(formatQuery);
     }
 
     /**
@@ -130,11 +131,11 @@ public final class MonetaryFormats {
      *                           corresponding {@link MonetaryAmountFormat} instance.
      */
     public static Collection<MonetaryAmountFormat> getAmountFormats(AmountFormatQuery formatQuery) {
-        if(monetaryFormatsSingletonSpi==null){
+        if(monetaryFormatsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return monetaryFormatsSingletonSpi.getAmountFormats(formatQuery);
+        return monetaryFormatsSingletonSpi().getAmountFormats(formatQuery);
     }
 
     /**
@@ -159,7 +160,7 @@ public final class MonetaryFormats {
      * @return all available locales, never {@code null}.
      */
     public static Set<Locale> getAvailableLocales(String... providers) {
-        return monetaryFormatsSingletonSpi.getAvailableLocales(providers);
+        return monetaryFormatsSingletonSpi().getAvailableLocales(providers);
     }
 
     /**
@@ -168,11 +169,11 @@ public final class MonetaryFormats {
      * @return the provider names, never null.
      */
     public static Collection<String> getFormatProviderNames() {
-        if(monetaryFormatsSingletonSpi==null){
+        if(monetaryFormatsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return monetaryFormatsSingletonSpi.getProviderNames();
+        return monetaryFormatsSingletonSpi().getProviderNames();
     }
 
     /**
@@ -181,11 +182,11 @@ public final class MonetaryFormats {
      * @return the default provider chain, never null.
      */
     public static List<String> getDefaultFormatProviderChain() {
-        if(monetaryFormatsSingletonSpi==null){
+        if(monetaryFormatsSingletonSpi()==null){
             throw new MonetaryException(
                     "No MonetaryFormatsSingletonSpi " + "loaded, query functionality is not available.");
         }
-        return monetaryFormatsSingletonSpi.getDefaultProviderChain();
+        return monetaryFormatsSingletonSpi().getDefaultProviderChain();
     }
 
     /**

--- a/src/test/java/javax/money/AbstractDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/AbstractDynamicServiceProviderTest.java
@@ -1,0 +1,110 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.money.spi.Bootstrap;
+import javax.money.spi.CurrencyProviderSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * Abstract test supporting to switch SPI implementations by using a ServiceProvider providing manually registered SPIs only. 
+ * @author Matthias Hanisch
+ */
+public abstract class AbstractDynamicServiceProviderTest {
+
+    private ServiceProvider originalServiceProvider;
+    private TestServiceProvider testServiceProvider;
+    
+    /**
+     * Initialized Bootstrap so that default ServiceProvider is enabled. Then stores the default ServiceProvider in
+     * {@link #originalServiceProvider}. Initializes Bootstrap with default ServiceProvider again so that it is
+     * usable in the Test. Also initialized {@link #testServiceProvider}.
+     */
+    @BeforeMethod
+    public void prepare() {
+        Bootstrap.getService(CurrencyProviderSpi.class);
+        ServiceProvider empty = Mockito.mock(ServiceProvider.class);
+        originalServiceProvider= Bootstrap.init(empty);
+        Bootstrap.init(originalServiceProvider);
+        testServiceProvider = new TestServiceProvider();
+    }
+    
+    /**
+     * Restores the default ServiceProvider.
+     */
+    @AfterMethod
+    public void restore() {
+        testServiceProvider.clearServices();
+        Bootstrap.init(originalServiceProvider);
+    }
+    
+    protected final void initTestServiceProvider() {
+        Bootstrap.init(testServiceProvider);
+    }
+    
+    protected final void initOriginalServiceProvider() {
+        Bootstrap.init(originalServiceProvider);
+    }
+
+    /**
+     * Registers a SPI service so that it is accessible via {@link Bootstrap#getService(Class)} when using {@link #testServiceProvider}.
+     * @param serviceType The SPI type.
+     * @param service The SPI instance.
+     */
+    protected final <T> void registerService(Class<T> serviceType, T service) {
+        testServiceProvider.registerService(serviceType, service);
+    }
+    
+    class TestServiceProvider implements ServiceProvider {
+        
+        private Map<Class<?>, List<?>> services = new HashMap<>();
+
+        @Override
+        public int getPriority() {
+            return 0;
+        }
+
+        @Override
+        public <T> List<T> getServices(Class<T> serviceType) {
+            return (List<T>) services.get(serviceType);
+        }
+
+        @Override
+        public <T> T getService(Class<T> serviceType) {
+            List<T> servicesOfType = getServices(serviceType);
+            if(servicesOfType==null||servicesOfType.isEmpty()) {
+                return null;
+            } else {
+                return servicesOfType.get(0);
+            }
+        }
+        
+        public <T> void registerService(Class<T> serviceType, T service) {
+            List<T> servicesOfType = (List<T>) services.get(serviceType);
+            if(servicesOfType==null) {
+                servicesOfType = new ArrayList<>();
+                services.put(serviceType, servicesOfType);
+            }
+            servicesOfType.add(service);
+        }
+        
+        public void clearServices() {
+            services.clear();
+        }
+    }
+}

--- a/src/test/java/javax/money/MonetaryDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/MonetaryDynamicServiceProviderTest.java
@@ -1,0 +1,199 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import javax.money.internal.DefaultMonetaryAmountsSingletonQuerySpi;
+import javax.money.internal.DefaultMonetaryAmountsSingletonSpi;
+import javax.money.spi.Bootstrap;
+import javax.money.spi.MonetaryAmountsSingletonQuerySpi;
+import javax.money.spi.MonetaryAmountsSingletonSpi;
+import javax.money.spi.MonetaryCurrenciesSingletonSpi;
+import javax.money.spi.MonetaryRoundingsSingletonSpi;
+import javax.money.spi.RoundingProviderSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+/**
+ * Test to ensure that singleton SPIs used by {@link Monetary} handle substitution of {@link ServiceProvider} to use when
+ * calling {@link Bootstrap#init(javax.money.spi.ServiceProvider)}. (e.g. in an OSGI environment)
+ * @author Matthias Hanisch
+ *
+ */
+public class MonetaryDynamicServiceProviderTest extends AbstractDynamicServiceProviderTest {
+    
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryCurrenciesSingletonSpi} supports currencies test1 and test2.
+     * Dynamic SPI: Mock supporting currencies test1 and test3. 
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>currency test1 available</li>
+     * <li>currency test2 available</li>
+     * <li>currency test3 <b>not</b> available</li>
+     * <li>use dynamic SPI</li>
+     * <li>currency test1 available</li>
+     * <li>currency test2 <b>not</b> available</li>
+     * <li>currency test3 available</li>
+     * <li>use default SPI</li>
+     * <li>currency test1 available</li>
+     * <li>currency test2 available</li>
+     * <li>currency test3 <b>not</b> available</li>
+     * </ul>
+     * 
+     */
+    @Test
+    public void testMonetaryCurrenciesSingletonSpi() {
+        // DefaultMonetaryCurrenciesSingletonSpi is used
+        assertCurrencyAvailable("test1");
+        assertCurrencyAvailable("test2");
+        assertCurrencyMissing("test3");
+        MonetaryCurrenciesSingletonSpi mockSingleton = Mockito.mock(MonetaryCurrenciesSingletonSpi.class);
+        registerService(MonetaryCurrenciesSingletonSpi.class, mockSingleton);
+        doAnswer(new Answer<CurrencyUnit>() {
+            private List<String> supportedCurrencies = Arrays.asList("test1","test3");
+            @Override
+            public CurrencyUnit answer(InvocationOnMock invocation)
+                    throws Throwable {
+                String currencyCode =(String)invocation.getArguments()[0];
+                if(supportedCurrencies.contains(currencyCode)) {
+                    return new TestCurrency(currencyCode, 1,2);
+                }
+                throw new UnknownCurrencyException(currencyCode);
+            }
+        }).when(mockSingleton).getCurrency(anyString());
+        initTestServiceProvider();
+        // DynamicMonetaryCurrenciesSingletonSpi is used
+        assertCurrencyAvailable("test1");
+        assertCurrencyMissing("test2");
+        assertCurrencyAvailable("test3");
+        initOriginalServiceProvider();
+        // DefaultMonetaryCurrenciesSingletonSpi is used again
+        assertCurrencyAvailable("test1");
+        assertCurrencyAvailable("test2");
+        assertCurrencyMissing("test3");
+    }
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryAmountsSingletonSpi} supports a {@link MonetaryAmountFactory} creating instances of DummyAmount.
+     * Dynamic SPI: Mock supporting a {@link MonetaryAmountFactory} creating a mocked {@link MonetaryAmount}
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>created MonetaryAmount should be a DummyAmount</li>
+     * <li>use dynamic SPI</li>
+     * <li>created MonetaryAmount should match the mocked Amount</li>
+     * <li>use default SPI</li>
+     * <li>created MonetaryAmount should be a DummyAmount</li>
+     * </ul>     
+     */
+    @Test
+    public void testMonetaryAmountsSingletonSpi() {
+        assertTrue(Monetary.getDefaultAmountFactory().create()instanceof DummyAmount);
+        MonetaryAmountsSingletonSpi mockSingleton = mock(MonetaryAmountsSingletonSpi.class);
+        MonetaryAmountFactory<?> mockFactory = mock(MonetaryAmountFactory.class);
+        MonetaryAmount mockAmount = mock(MonetaryAmount.class);
+        doReturn(mockFactory).when(mockSingleton).getDefaultAmountFactory();
+        doReturn(mockAmount).when(mockFactory).create();
+        registerService(MonetaryAmountsSingletonSpi.class, mockSingleton);
+        initTestServiceProvider();
+        assertFalse(Monetary.getDefaultAmountFactory().create()instanceof DummyAmount);
+        assertEquals(Monetary.getDefaultAmountFactory().create(), mockAmount);
+        initOriginalServiceProvider();
+        assertTrue(Monetary.getDefaultAmountFactory().create()instanceof DummyAmount);
+    }
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryAmountsSingletonQuerySpi} supports {@link MonetaryAmountFactoryQuery} for DummyAmount.
+     * Dynamic SPI: Mock not supporting {@link MonetaryAmountFactoryQuery} for none MonetaryMount at all.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>query for DummyAmount should be true</li>
+     * <li>use dynamic SPI</li>
+     * <li>query for DummyAmount should be false</li>
+     * <li>use default SPI</li>
+     * <li>query for DummyAmount should be true</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryAmountsSingletonQuerySpi() {
+        MonetaryAmountFactoryQuery query = MonetaryAmountFactoryQueryBuilder.of()
+        .setTargetType(DummyAmount.class).build();
+        assertTrue(Monetary.isAvailable(query));
+        MonetaryAmountsSingletonQuerySpi mock= mock(MonetaryAmountsSingletonQuerySpi.class);
+        doReturn(Boolean.FALSE).when(mock).isAvailable(any(MonetaryAmountFactoryQuery.class));
+        registerService(MonetaryAmountsSingletonQuerySpi.class, mock);
+        initTestServiceProvider();
+        assertFalse(Monetary.isAvailable(query));
+        initOriginalServiceProvider();
+        assertTrue(Monetary.isAvailable(query));
+    }
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryRoundingsSingletonSpi} uses {@link RoundingProviderSpi} supporting two rounding names.
+     * Dynamic SPI: Mock supporting one rounding name.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>number of rounding names should be two</li>
+     * <li>use dynamic SPI</li>
+     * <li>number of rounding names should be one</li>
+     * <li>use default SPI</li>
+     * <li>number of rounding names should be two</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryRoundingsSingletonSpi() {
+        assertEquals(Monetary.getRoundingNames().size(),2);
+        MonetaryRoundingsSingletonSpi mock = mock(MonetaryRoundingsSingletonSpi.class);
+        doReturn(new HashSet<>(Arrays.asList("dummyRounding"))).when(mock).getRoundingNames();
+        registerService(MonetaryRoundingsSingletonSpi.class, mock);
+        initTestServiceProvider();
+        assertEquals(Monetary.getRoundingNames().size(),1);
+        initOriginalServiceProvider();
+        assertEquals(Monetary.getRoundingNames().size(),2);
+    }
+    
+    private void assertCurrencyAvailable(String currency) {
+        CurrencyUnit cur = Monetary.getCurrency(currency);
+        assertNotNull(cur);
+    }
+    
+    private void assertCurrencyMissing(String currency) {
+        try {
+            CurrencyUnit cur = Monetary.getCurrency(currency);
+            fail(String.format("currency %s should not be available, but got %s", currency, cur));
+        } catch(UnknownCurrencyException ex) {
+            ex.printStackTrace();
+            // expected
+        }
+    }
+    
+
+}

--- a/src/test/java/javax/money/TestCurrency.java
+++ b/src/test/java/javax/money/TestCurrency.java
@@ -55,7 +55,7 @@ public final class TestCurrency implements CurrencyUnit, Serializable, Comparabl
     /**
      * Private constructor.
      */
-    private TestCurrency(String code, int numCode, int fractionDigits) {
+    TestCurrency(String code, int numCode, int fractionDigits) {
         this.currencyCode = code;
         this.numericCode = numCode;
         this.defaultFractionDigits = fractionDigits;

--- a/src/test/java/javax/money/convert/MonetaryConversionsDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/convert/MonetaryConversionsDynamicServiceProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money.convert;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import javax.money.internal.DefaultMonetaryAmountsSingletonQuerySpi;
+import javax.money.internal.DefaultMonetaryAmountsSingletonSpi;
+import javax.money.spi.Bootstrap;
+import javax.money.spi.MonetaryAmountsSingletonQuerySpi;
+import javax.money.spi.MonetaryAmountsSingletonSpi;
+import javax.money.spi.MonetaryConversionsSingletonSpi;
+import javax.money.spi.MonetaryCurrenciesSingletonSpi;
+import javax.money.spi.MonetaryRoundingsSingletonSpi;
+import javax.money.spi.RoundingProviderSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+import javax.money.AbstractDynamicServiceProviderTest;
+import javax.money.format.MonetaryFormats;
+import javax.money.format.MonetaryFormats.DefaultMonetaryFormatsSingletonSpi;
+
+/**
+ * Test to ensure that singleton SPIs used by {@link MonetaryConversions} handle substitution of {@link ServiceProvider} to use when
+ * calling {@link Bootstrap#init(javax.money.spi.ServiceProvider)}. (e.g. in an OSGI environment)
+ * @author Matthias Hanisch
+ *
+ */
+public class MonetaryConversionsDynamicServiceProviderTest
+        extends AbstractDynamicServiceProviderTest {
+
+    /**
+     * Default test SPI: {@link TestMonetaryConversionsSingletonSpi} supports one conversion provider name.
+     * Dynamic SPI: Mock supporting two conversion provider names.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>number of conversion provider names should be one</li>
+     * <li>use dynamic SPI</li>
+     * <li>number of conversion provider names should be two</li>
+     * <li>use default SPI</li>
+     * <li>number of conversion provider names should be one</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryConversionsSingletonSpi() {
+        assertEquals(MonetaryConversions.getConversionProviderNames().size(),1);
+        MonetaryConversionsSingletonSpi mock = mock(MonetaryConversionsSingletonSpi.class);
+        doReturn(new HashSet<String>(Arrays.asList("conversionProviderOne","conversionProviderTwo"))).when(mock).getProviderNames();
+        registerService(MonetaryConversionsSingletonSpi.class, mock);
+        initTestServiceProvider();
+        assertEquals(MonetaryConversions.getConversionProviderNames().size(),2);
+        initOriginalServiceProvider();
+        assertEquals(MonetaryConversions.getConversionProviderNames().size(),1);
+        
+    }
+}

--- a/src/test/java/javax/money/format/MonetaryFormatsDynamicServiceProviderTest.java
+++ b/src/test/java/javax/money/format/MonetaryFormatsDynamicServiceProviderTest.java
@@ -1,0 +1,60 @@
+/*
+ * CREDIT SUISSE IS WILLING TO LICENSE THIS SPECIFICATION TO YOU ONLY UPON THE CONDITION THAT YOU
+ * ACCEPT ALL OF THE TERMS CONTAINED IN THIS AGREEMENT. PLEASE READ THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT CAREFULLY. BY DOWNLOADING THIS SPECIFICATION, YOU ACCEPT THE TERMS AND CONDITIONS OF
+ * THE AGREEMENT. IF YOU ARE NOT WILLING TO BE BOUND BY IT, SELECT THE "DECLINE" BUTTON AT THE
+ * BOTTOM OF THIS PAGE. Specification: JSR-354 Money and Currency API ("Specification") Copyright
+ * (c) 2012-2013, Credit Suisse All rights reserved.
+ */
+package javax.money.format;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import javax.money.AbstractDynamicServiceProviderTest;
+import javax.money.format.MonetaryFormats.DefaultMonetaryFormatsSingletonSpi;
+import javax.money.spi.Bootstrap;
+import javax.money.spi.MonetaryFormatsSingletonSpi;
+import javax.money.spi.ServiceProvider;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test to ensure that singleton SPIs used by {@link MonetaryFormats} handle substitution of {@link ServiceProvider} to use when
+ * calling {@link Bootstrap#init(javax.money.spi.ServiceProvider)}. (e.g. in an OSGI environment)
+ * @author Matthias Hanisch
+ *
+ */
+public class MonetaryFormatsDynamicServiceProviderTest
+        extends AbstractDynamicServiceProviderTest {
+
+    
+    /**
+     * Default SPI: {@link DefaultMonetaryFormatsSingletonSpi} supports one format provider name.
+     * Dynamic SPI: Mock supporting two format provider names.
+     * Testing following steps:
+     * <ul>
+     * <li>use default SPI</li>
+     * <li>number of format provider names should be one</li>
+     * <li>use dynamic SPI</li>
+     * <li>number of format provider names should be two</li>
+     * <li>use default SPI</li>
+     * <li>number of format provider names should be one</li>
+     * </ul>
+     */
+    @Test
+    public void testMonetaryFormatsSingletonSpi() {
+        assertEquals(MonetaryFormats.getFormatProviderNames().size(),1);
+        MonetaryFormatsSingletonSpi mock = mock(MonetaryFormatsSingletonSpi.class);
+        doReturn(new HashSet<String>(Arrays.asList("formatProviderOne","formatProviderTow"))).when(mock).getProviderNames();
+        registerService(MonetaryFormatsSingletonSpi.class, mock);
+        initTestServiceProvider();
+        assertEquals(MonetaryFormats.getFormatProviderNames().size(),2);
+        initOriginalServiceProvider();
+        assertEquals(MonetaryFormats.getFormatProviderNames().size(),1);
+    }
+}


### PR DESCRIPTION
In a dynamic environment such as OSGI, SPI instances are registered
dynamically. The classes Monetary, MonetaryConversions and
MonetaryFormats keep static references to SPI instances. This breaks
usage of money-api in OSGI as SPI instances may be registered delayed.

To ensure that using money-api is in an OSGI environment is possible,
references to SPI instances should be resolved dynamically.

Added tests for Monetary, MonetaryFormats and MonetaryConversions.